### PR TITLE
chore: add vamm attribute in action

### DIFF
--- a/contracts/margined_engine/src/handle.rs
+++ b/contracts/margined_engine/src/handle.rs
@@ -798,7 +798,8 @@ pub fn pay_funding(
 
     Ok(Response::new()
         .add_submessage(funding_msg)
-        .add_attribute("action", "pay_funding"))
+        .add_attribute("action", "pay_funding")
+        .add_attribute("vamm", &vamm))
 }
 
 /// Enables a user to directly deposit margin into their position
@@ -854,6 +855,7 @@ pub fn deposit_margin(
         ("position_id", &position_id.to_string()),
         ("trader", trader.as_ref()),
         ("deposit_amount", &amount.to_string()),
+        ("vamm", &vamm),
     ]))
 }
 
@@ -933,6 +935,7 @@ pub fn withdraw_margin(
             &remain_margin.latest_premium_fraction.to_string(),
         ),
         ("bad_debt", &remain_margin.bad_debt.to_string()),
+        ("vamm", &vamm),
     ]))
 }
 

--- a/contracts/margined_vamm/src/handle.rs
+++ b/contracts/margined_vamm/src/handle.rs
@@ -136,7 +136,11 @@ pub fn set_open(deps: DepsMut, env: Env, info: MessageInfo, open: bool) -> StdRe
 
     store_state(deps.storage, &state)?;
 
-    Ok(Response::new().add_attribute("action", "set_open"))
+    Ok(Response::new()
+        .add_attribute("action", "set_open")
+        .add_attribute("vamm", &env.contract.address)
+        .add_attribute("base_asset", config.base_asset)
+        .add_attribute("quote_asset", config.quote_asset))
 }
 
 pub fn migrate_liquidity(


### PR DESCRIPTION
- [ ] - Add `vamm` attribute in `engine` action to make events more clearly.
- [ ] - Add `vamm`, `base_asset` and `quote_asset` to make action `set_open`'s event more clearly.